### PR TITLE
Fixing webpack config to allow Developer VM

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,6 +1,7 @@
 const HtmlWebpackInlineSourcePlugin = require('html-webpack-inline-source-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const path = require('path')
+const webpack = require('webpack')
 
 module.exports = (env, argv) => ({
   mode: argv.mode === 'production' ? 'production' : 'development',
@@ -36,6 +37,9 @@ module.exports = (env, argv) => ({
 
   // Tells Webpack to generate "ui.html" and to inline "ui.ts" into it
   plugins: [
+    new webpack.DefinePlugin({
+      'global': {} // Fix missing symbol error when running in developer VM
+    }),
     new HtmlWebpackPlugin({
       template: './src/ui.html',
       filename: 'ui.html',


### PR DESCRIPTION
Pretty self-explanatory, but this fixes an issue where attempting to run the Developer VM against the included webpack example will throw an error in Figma for a missing `global` symbol. This has to do with the `global` object not being defined, and Figma therefore not being able to find `global.window`.