### PR TITLE
set tsconfig 'lib' to 'es6'

### DIFF
--- a/barchart/tsconfig.json
+++ b/barchart/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/circletext/tsconfig.json
+++ b/circletext/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/create-rects-shapes/tsconfig.json
+++ b/create-rects-shapes/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/create-shapes-connectors/tsconfig.json
+++ b/create-shapes-connectors/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/invert-image/tsconfig.json
+++ b/invert-image/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/metacards/tsconfig.json
+++ b/metacards/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/piechart/tsconfig.json
+++ b/piechart/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/resizer/tsconfig.json
+++ b/resizer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/sierpinski/tsconfig.json
+++ b/sierpinski/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/stats/tsconfig.json
+++ b/stats/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/svg-inserter/tsconfig.json
+++ b/svg-inserter/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/text-search/tsconfig.json
+++ b/text-search/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/vector-path/tsconfig.json
+++ b/vector-path/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"

--- a/vote-tally/tsconfig.json
+++ b/vote-tally/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "lib": ["es6"],
     "typeRoots": [
       "../node_modules/@types",
       "../node_modules/@figma"


### PR DESCRIPTION
This matches how the plugin skeleton project is set up.

It has the effect of hiding the browser APIs (e.g. fetch, or console.trace)
by default, as they are not accessible from plugins.

This leaves out the webpack-react sample as it needs more surgery first.