### PR TITLE
set HtmlWebpackPlugin cache as false

### DIFF
--- a/webpack-react/webpack.config.js
+++ b/webpack-react/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = (env, argv) => ({
       'global': {} // Fix missing symbol error when running in developer VM
     }),
     new HtmlWebpackPlugin({
+      cache: false,
       inject: "body",
       template: './src/ui.html',
       filename: 'ui.html',


### PR DESCRIPTION
because the code is inline, so if cache the HTML, the code will not reload.