### PR TITLE
add network access field to all sample manifests

### DIFF
--- a/barchart/code.ts
+++ b/barchart/code.ts
@@ -1,6 +1,6 @@
 figma.showUI(__html__)
 figma.ui.onmessage = async (numbers) => {
-  // Roboto Regular is the font that objects will be created with by default in
+  // Inter Regular is the font that objects will be created with by default in
   // Figma. We need to wait for fonts to load before creating text using them.
   await figma.loadFontAsync({ family: "Inter", style: "Regular" })
 

--- a/barchart/code.ts
+++ b/barchart/code.ts
@@ -2,7 +2,7 @@ figma.showUI(__html__)
 figma.ui.onmessage = async (numbers) => {
   // Roboto Regular is the font that objects will be created with by default in
   // Figma. We need to wait for fonts to load before creating text using them.
-  await figma.loadFontAsync({ family: "Roboto", style: "Regular" })
+  await figma.loadFontAsync({ family: "Inter", style: "Regular" })
 
   const frameWidth = 800
   const frameHeight = 600

--- a/barchart/manifest.json
+++ b/barchart/manifest.json
@@ -7,7 +7,9 @@
   "editorType": ["figma", "figjam"],
   "networkAccess": {
     "allowedDomains": [
-      "https://static.figma.com/api/figma-extension-api-0.0.1.css"
+      "https://static.figma.com/api/figma-extension-api-0.0.1.css",
+      "https://fonts.googleapis.com",
+      "https://fonts.gstatic.com"
     ]
   }
 }

--- a/barchart/manifest.json
+++ b/barchart/manifest.json
@@ -1,7 +1,13 @@
 {
+  "id": "bar-chart-sample",
   "name": "Bar Chart Sample",
   "api": "1.0.0",
   "main": "code.js",
   "ui": "ui.html",
-  "editorType": ["figma", "figjam"]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": [
+      "https://static.figma.com/api/figma-extension-api-0.0.1.css"
+    ]
+  }
 }

--- a/capital/manifest.json
+++ b/capital/manifest.json
@@ -10,5 +10,8 @@
       "key": "country",
       "description": "Select a country to find its capital city."
     }
-  ]
+  ],
+  "networkAccess": {
+    "allowedDomains": ["https://api.sampleapis.com/countries/countries"]
+  }
 }

--- a/circletext/code.ts
+++ b/circletext/code.ts
@@ -33,7 +33,7 @@ function rotate(theta) {
 async function main(): Promise<string | undefined> {
   // Roboto Regular is the font that objects will be created with by default in
   // Figma. We need to wait for fonts to load before creating text using them.
-  await figma.loadFontAsync({ family: "Roboto", style: "Regular" })
+  await figma.loadFontAsync({ family: "Inter", style: "Regular" })
 
   // Make sure the selection is a single piece of text before proceeding.
   if (figma.currentPage.selection.length !== 1) {

--- a/circletext/code.ts
+++ b/circletext/code.ts
@@ -31,7 +31,7 @@ function rotate(theta) {
 // MAIN PLUGIN CODE
 
 async function main(): Promise<string | undefined> {
-  // Roboto Regular is the font that objects will be created with by default in
+  // Inter Regular is the font that objects will be created with by default in
   // Figma. We need to wait for fonts to load before creating text using them.
   await figma.loadFontAsync({ family: "Inter", style: "Regular" })
 

--- a/circletext/manifest.json
+++ b/circletext/manifest.json
@@ -1,5 +1,10 @@
 {
+  "id": "circle-text-sample",
   "name": "Circle Text Sample",
   "api": "1.0.0",
   "main": "code.js",
-  "editorType": ["figma", "figjam"]}
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
+}

--- a/create-rects-shapes/code.ts
+++ b/create-rects-shapes/code.ts
@@ -48,7 +48,6 @@ if (figma.editorType === 'figma') {
   
   for (let i = 0; i < (numberOfShapes - 1); i++) {
     const connector = figma.createConnector();
-    const strokeWeight = {...connector.strokeWeight};
     connector.strokeWeight = 8
     
     connector.connectorStart = {

--- a/create-rects-shapes/manifest.json
+++ b/create-rects-shapes/manifest.json
@@ -3,8 +3,8 @@
   "id": "1009724408344532126",
   "api": "1.0.0",
   "main": "code.js",
-  "editorType": [
-    "figma",
-    "figjam"
-  ]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/create-shapes-connectors/code.ts
+++ b/create-shapes-connectors/code.ts
@@ -18,7 +18,6 @@ for (let i = 0; i < numberOfShapes; i++) {
 
 for (let i = 0; i < (numberOfShapes - 1); i++) {
   const connector = figma.createConnector();
-  const strokeWeight = {...connector.strokeWeight};
   connector.strokeWeight = 8
   
   connector.connectorStart = {

--- a/create-shapes-connectors/manifest.json
+++ b/create-shapes-connectors/manifest.json
@@ -3,7 +3,8 @@
   "id": "1009709756337344668",
   "api": "1.0.0",
   "main": "code.js",
-  "editorType": [
-    "figjam"
-  ]
+  "editorType": ["figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/document-change/manifest.json
+++ b/document-change/manifest.json
@@ -1,7 +1,11 @@
 {
+  "id": "document-change-sample",
   "name": "Document Change Sample",
   "api": "1.0.0",
   "main": "code.js",
   "ui": "ui.html",
-  "editorType": ["figma", "figjam"]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/esbuild-react/manifest.json
+++ b/esbuild-react/manifest.json
@@ -1,9 +1,12 @@
 {
   "name": "React Sample",
-  "id": "",
+  "id": "react-sample",
   "api": "1.0.0",
   "editorType": ["figma", "figjam"],
   "permissions": [],
   "main": "dist/code.js",
-  "ui": "dist/index.html"
+  "ui": "dist/index.html",
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/go-to/manifest.json
+++ b/go-to/manifest.json
@@ -3,15 +3,15 @@
   "id": "1020470258681431214",
   "api": "1.0.0",
   "main": "code.js",
-  "editorType": [
-    "figma",
-    "figjam"
-  ],
+  "editorType": ["figma", "figjam"],
   "parameters": [
     {
       "name": "Page or Layer Name",
       "key": "name",
       "description": "Name of the location you want to go to"
     }
-  ]
+  ],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/icon-drag-and-drop-hosted/manifest.json
+++ b/icon-drag-and-drop-hosted/manifest.json
@@ -1,10 +1,12 @@
 {
+  "id": "drag-and-drop-hosted",
   "name": "drag-and-drop-hosted",
   "api": "1.0.0",
   "main": "code.js",
-  "editorType": [
-    "figma",
-    "figjam"
-  ],
-  "ui": "ui.html"
+  "editorType": ["figma", "figjam"],
+  "ui": "ui.html",
+  "networkAccess": {
+    "allowedDomains": ["*"],
+    "reasoning": "localhost is used for development purposes only."
+  }
 }

--- a/icon-drag-and-drop/code.ts
+++ b/icon-drag-and-drop/code.ts
@@ -5,7 +5,7 @@ figma.on('drop', (event) => {
   const { files, node, dropMetadata } = event;
 
   if (files.length > 0 && files[0].type === 'image/svg+xml') {
-    files[0].getTextAsync().then(text => {
+    files[0].getTextAsync().then((text) => {
       if (dropMetadata.parentingStrategy === 'page') {
         const newNode = figma.createNodeFromSvg(text);
         newNode.x = event.absoluteX;
@@ -15,7 +15,8 @@ figma.on('drop', (event) => {
       } else if (dropMetadata.parentingStrategy === 'immediate') {
         const newNode = figma.createNodeFromSvg(text);
 
-        if (node.appendChild) {
+        // We can only append page nodes to documents
+        if ('appendChild' in node && node.type !== 'DOCUMENT') {
           node.appendChild(newNode);
         }
 

--- a/icon-drag-and-drop/manifest.json
+++ b/icon-drag-and-drop/manifest.json
@@ -7,7 +7,9 @@
   "editorType": ["figma", "figjam"],
   "networkAccess": {
     "allowedDomains": [
-      "https://static.figma.com/api/figma-extension-api-0.0.1.css"
+      "https://static.figma.com/api/figma-extension-api-0.0.1.css",
+      "https://fonts.googleapis.com",
+      "https://fonts.gstatic.com"
     ]
   }
 }

--- a/icon-drag-and-drop/manifest.json
+++ b/icon-drag-and-drop/manifest.json
@@ -1,7 +1,13 @@
 {
+  "id": "icon-drag-and-drop-sample",
   "name": "Icon Drag-and-Drop Sample",
   "api": "1.0.0",
   "main": "code.js",
   "ui": "ui.html",
-  "editorType": ["figma", "figjam"]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": [
+      "https://static.figma.com/api/figma-extension-api-0.0.1.css"
+    ]
+  }
 }

--- a/invert-image/manifest.json
+++ b/invert-image/manifest.json
@@ -1,7 +1,11 @@
 {
+  "id": "invert-image-color-sample",
   "name": "Invert Image Color Sample",
   "api": "1.0.0",
   "main": "code.js",
   "ui": "decoder.html",
-  "editorType": ["figma", "figjam"]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/invert-image/manifest.json
+++ b/invert-image/manifest.json
@@ -6,6 +6,7 @@
   "ui": "decoder.html",
   "editorType": ["figma", "figjam"],
   "networkAccess": {
-    "allowedDomains": ["none"]
+    "allowedDomains": ["*"],
+    "reasoning": "blob urls are not yet supported for networkAccess"
   }
 }

--- a/metacards/manifest.json
+++ b/metacards/manifest.json
@@ -6,6 +6,6 @@
   "editorType": ["figma", "figjam"],
   "ui": "ui.html",
   "networkAccess": {
-    "allowedDomains": ["https://cors-anywhere.com"]
+    "allowedDomains": ["https://cors-anywhere.herokuapp.com"]
   }
 }

--- a/metacards/manifest.json
+++ b/metacards/manifest.json
@@ -3,9 +3,9 @@
   "id": "1010531604887911850",
   "api": "1.0.0",
   "main": "code.js",
-  "editorType": [
-    "figma",
-    "figjam"
-  ],
-  "ui": "ui.html"
+  "editorType": ["figma", "figjam"],
+  "ui": "ui.html",
+  "networkAccess": {
+    "allowedDomains": ["https://cors-anywhere.com"]
+  }
 }

--- a/metacards/ui.html
+++ b/metacards/ui.html
@@ -28,7 +28,7 @@
       // cross origin using cors-anywhere
 			img.onerror = () => {
         if(img.src.indexOf("cors-anywhere") === -1){
-          img.src = `https://cors-anywhere.com/${url.replace(/http(s)?:\/\//,'')}`;
+          img.src = `https://cors-anywhere.herokuapp.com/${url.replace(/http(s)?:\/\//,'')}`;
         } else {
           reject("Error fetching image");
         }
@@ -44,7 +44,7 @@
   async function fetchMetaTags(url){
     
     return new Promise(function(resolve, reject) {
-      let fetchUrl = `https://cors-anywhere.com/${url.replace(/http(s)?:\/\//,'')}`;
+      let fetchUrl = `https://cors-anywhere.herokuapp.com/${url.replace(/http(s)?:\/\//,'')}`;
 
       fetch(fetchUrl).then(function (response) {
         // The API call was successful!

--- a/piechart/manifest.json
+++ b/piechart/manifest.json
@@ -7,7 +7,9 @@
   "editorType": ["figma", "figjam"],
   "networkAccess": {
     "allowedDomains": [
-      "https://static.figma.com/api/figma-extension-api-0.0.1.css"
+      "https://static.figma.com/api/figma-extension-api-0.0.1.css",
+      "https://fonts.googleapis.com",
+      "https://fonts.gstatic.com"
     ]
   }
 }

--- a/piechart/manifest.json
+++ b/piechart/manifest.json
@@ -1,7 +1,13 @@
 {
+  "id": "pie-chart-sample",
   "name": "Pie Chart Sample",
   "api": "1.0.0",
   "main": "code.js",
   "ui": "ui.html",
-  "editorType": ["figma", "figjam"]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": [
+      "https://static.figma.com/api/figma-extension-api-0.0.1.css"
+    ]
+  }
 }

--- a/png-crop/manifest.json
+++ b/png-crop/manifest.json
@@ -1,6 +1,10 @@
 {
+  "id": "png-crop",
   "name": "PNG Crop",
   "api": "1.0.0",
   "main": "code.js",
-  "editorType": ["figma", "figjam"]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/post-message/manifest.json
+++ b/post-message/manifest.json
@@ -1,7 +1,11 @@
 {
+  "id": "post-message",
   "name": "Post Message",
   "api": "1.0.0",
   "main": "code.js",
   "editorType": ["figma", "figjam"],
-  "ui": "ui.html"
+  "ui": "ui.html",
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/resizer/manifest.json
+++ b/resizer/manifest.json
@@ -32,5 +32,8 @@
         }
       ]
     }
-  ]
+  ],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/sierpinski/manifest.json
+++ b/sierpinski/manifest.json
@@ -1,6 +1,10 @@
 {
+  "id": "sierpinski-sample",
   "name": "Sierpinski Sample",
   "api": "1.0.0",
   "main": "code.js",
-  "editorType": ["figma", "figjam"]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/stats/manifest.json
+++ b/stats/manifest.json
@@ -1,6 +1,10 @@
 {
+  "id": "document-statistics-sample",
   "name": "Document Statistics Sample",
   "api": "1.0.0",
   "main": "code.js",
-  "editorType": ["figma", "figjam"]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/svg-inserter/manifest.json
+++ b/svg-inserter/manifest.json
@@ -22,5 +22,8 @@
       "description": "enter the color of the icon you want to insert",
       "optional": true
     }
-  ]
+  ],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/text-review/manifest.json
+++ b/text-review/manifest.json
@@ -5,5 +5,8 @@
   "main": "code.js",
   "editorType": ["figma"],
   "capabilities": ["textreview"],
-  "enableProposedApi": true
+  "enableProposedApi": true,
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/text-search/manifest.json
+++ b/text-search/manifest.json
@@ -1,7 +1,11 @@
 {
+  "id": "text-search-sample",
   "name": "Text Search Sample",
   "api": "1.0.0",
   "main": "code.js",
   "ui": "ui.html",
-  "editorType": ["figma", "figjam"]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/trivia/manifest.json
+++ b/trivia/manifest.json
@@ -31,5 +31,8 @@
       "description": "Multiple choice or true/false",
       "optional": true
     }
-  ]
+  ],
+  "networkAccess": {
+    "allowedDomains": ["https://opentdb.com/"]
+  }
 }

--- a/vector-path/manifest.json
+++ b/vector-path/manifest.json
@@ -1,6 +1,10 @@
 {
+  "id": "vector-path-sample",
   "name": "Vector Path Sample",
   "api": "1.0.0",
   "main": "code.js",
-  "editorType": ["figma", "figjam"]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/vote-tally/code.ts
+++ b/vote-tally/code.ts
@@ -137,19 +137,17 @@ async function tallyStickyVotes(sticky, removeStamps = false){
 if(stickies.length > 0){
 
   // Tally up each sticky's votes 
-  stickies.forEach(sticky => {
-    tallyStickyVotes(sticky, true);
-  })
-
-  // Notify the user 
-  figma.notify(`Tallied ${stickies.length} ${stickies.length > 1? 'stickies' : 'sticky' }.`);
-
+  Promise.all(stickies.map(sticky => tallyStickyVotes(sticky))).then(() => {
+    // Notify the user 
+    figma.notify(`Tallied ${stickies.length} ${stickies.length > 1? 'stickies' : 'sticky' }.`);
+    figma.closePlugin();
+  }).catch(error => {
+    figma.closePlugin();
+  });
 } else {
-  
   figma.notify(`No stickies found. Add some!`);
-
+  // Make sure to close the plugin when you're done. Otherwise the plugin will
+  // keep running, which shows the cancel button at the bottom of the screen.
+  figma.closePlugin();
 }
 
-// Make sure to close the plugin when you're done. Otherwise the plugin will
-// keep running, which shows the cancel button at the bottom of the screen.
-figma.closePlugin();

--- a/vote-tally/manifest.json
+++ b/vote-tally/manifest.json
@@ -3,7 +3,8 @@
   "id": "1010229183389496680",
   "api": "1.0.0",
   "main": "code.js",
-  "editorType": [
-    "figjam"
-  ]
+  "editorType": ["figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }

--- a/webpack-react/manifest.json
+++ b/webpack-react/manifest.json
@@ -1,8 +1,11 @@
 {
   "name": "Webpack + React Sample",
-  "id": "",
+  "id": "webpack-react-sample",
   "api": "1.0.0",
   "main": "dist/code.js",
   "ui": "dist/ui.html",
-  "editorType": ["figma", "figjam"]
+  "editorType": ["figma", "figjam"],
+  "networkAccess": {
+    "allowedDomains": ["none"]
+  }
 }


### PR DESCRIPTION
Describe:
Adding the `networkAccess` field to all our plugin samples. Most are fairly straightforward and could just be `["none"]` the ones that weren't are:
- **barchart**, **icon-drag-and-drop**, **piechart**: for various imported styles
- **icon-drag-and-drop**: uses * since it's using localhost
- **invert-image**: uses * since it's using blob urls - gonna have to dig in deeper here to see if we can default allow blobs or have these be specifiable in the manifest.json
- **metacards**: uses https://cors-anywhere.herokuapp.com (previously it was using https://cors-anywhere.com - but I couldn't get this to work. The herokuapp one is based on https://github.com/Rob--W/cors-anywhere/
- **trivia**: uses https://opentdb.com/ (open trivia database)
- **capital**: uses https://api.sampleapis.com/countries/countries to get the capitals for a given country

I also added an id for any manifests that didn't specify one since the plugin no-ops when running a plugin in development that doesn't have an id

## Test Plan
run all the plugins and assert they work.
From doing this, I discovered some of them don't haha. So I fixed these in a separate commit