### PR TITLE
Fix: solves the duplicate variable name error in styles-to-variables plugin

### DIFF
--- a/styles-to-variables/code.js
+++ b/styles-to-variables/code.js
@@ -9,6 +9,22 @@ function createTokens(tokenData) {
   if (tokenData.length <= 0) {
     figma.notify("No convertible styles found. :(");
     return;
+  } else {
+    const tokens = tokenData.map(item => item.tokens);
+    const tokenCount = {};
+
+    tokenData.forEach(item => {
+        const {tokens} = item;
+        if (tokens.length === 1) {
+            const token = tokens[0];
+            if (tokenCount[token] === undefined) {
+                tokenCount[token] = 1;
+            } else {
+                tokenCount[token]++;
+                tokens[0] = `${token}${tokenCount[token]}`;
+            }
+        }
+    });
   }
   const collection = figma.variables.createVariableCollection(`Style Tokens`);
   let aliasCollection;


### PR DESCRIPTION
Hello! I believe the root cause of the issue #142 stems from having multiple styles associated with the same "token" name. To avoid a repeat of this incident, we can rectify the tokenData by appending a numerical suffix to the token style names. That being said, I have devised an alternate solution that may be of interest to you. Thank you for your time, and your attention.  