### PR TITLE
refactor: migrate variables sample to TS

### DIFF
--- a/variables-import-export/.gitignore
+++ b/variables-import-export/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+code.js

--- a/variables-import-export/package-lock.json
+++ b/variables-import-export/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "variables",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "variables",
+      "version": "1.0.0",
+      "license": "MIT License",
+      "devDependencies": {
+        "@figma/plugin-typings": "*",
+        "typescript": "^5.3.2"
+      }
+    },
+    "node_modules/@figma/plugin-typings": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.81.0.tgz",
+      "integrity": "sha512-gy/q4Aa/oVmN9PxdrUyuiMpoBpXAkGIpbe4nqHiKK1TDjrxW3ZBwmYzCM3uGUTC63xhwk99vExbBxaHsoSrAGw==",
+      "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  },
+  "dependencies": {
+    "@figma/plugin-typings": {
+      "version": "1.81.0",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.81.0.tgz",
+      "integrity": "sha512-gy/q4Aa/oVmN9PxdrUyuiMpoBpXAkGIpbe4nqHiKK1TDjrxW3ZBwmYzCM3uGUTC63xhwk99vExbBxaHsoSrAGw==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "dev": true
+    }
+  }
+}

--- a/variables-import-export/package.json
+++ b/variables-import-export/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "variables",
+  "version": "1.0.0",
+  "description": "variables",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "watch": "npm run build -- --watch"
+  },
+  "author": "Figma",
+  "license": "MIT License",
+  "devDependencies": {
+    "@figma/plugin-typings": "*",
+    "typescript": "^5.3.2"
+  }
+}

--- a/variables-import-export/tsconfig.json
+++ b/variables-import-export/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "lib": ["ES2017"],
+    "strict": true,
+    "typeRoots": [
+      "./node_modules/@types",
+      "./node_modules/@figma"
+    ]
+  }
+}


### PR DESCRIPTION
## Motivation

I am creating a plugin based on the `variables-import-export` sample. I found the code is relatively more complicated than other samples. Migrating it to TS as well as other samples will be beneficial from the perspective of readability and customizability.

