### PR TITLE
Include Plugma CLI in plugin-samples readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Create rectangles! This demonstrates:
 - [Figma Plugin Boilerplate](https://github.com/thomas-lowry/figma-plugin-boilerplate) - A starter project for creating Figma Plugins with HTML, CSS (+ SCSS) and vanilla Javascript without any frameworks.
 - [Figsvelte](https://github.com/thomas-lowry/figsvelte) - A boilerplate for creating Figma plugins using Svelte.
 - [Figplug](https://rsms.me/figplug/) - A small program for building Figma plugins. It offers all the things you need for most projects: TypeScript, React/JSX, asset bundling, plugin manifest generation, etc.
+- [Plugma](https://github.com/gavinmcfarland/plugma) - A CLI for simplifying creating plugins. It uses a local dev server for faster development and better debugging. Built with Vite, so it supports most frameworks, with more being added.
 
 [docs]: https://www.figma.com/plugin-docs/
 [help]: https://www.figma.com/plugin-docs/get-help


### PR DESCRIPTION
Would it be possible to add a link to my CLI that I created that makes it easy to create a plugin using most frameworks? It currently supports React, Svelet, Typescript, and Vanilla JS. It takes care of bundling using Vite, so it supports Vite and Rollup plugins. When developing, it uses a local dev server for faster development and better debugging. Plus it includes the option the preview plugin UI in any browser and uses web sockets to pass messages from Figma editor to the browser.