### PR TITLE
Fixed code.js

### DIFF
--- a/dev-mode/code.js
+++ b/dev-mode/code.js
@@ -1,11 +1,13 @@
 if (figma.editorType === "dev") {
   if (figma.mode === "inspect") {
-    figma.showUI("<h1>This is Dev Mode!</h1>");
+    figma.showUI(__html__); // Ensure you define __html__ in your plugin UI
   } else if (figma.mode === "codegen") {
-    figma.codegen.on("generate", () => [
-      { title: "Codegen", code: "This is codegen!", language: "PLAINTEXT" },
-    ]);
+    figma.codegen.on("generate", () => {
+      return [
+        { title: "Codegen", code: "This is codegen!", language: "PLAINTEXT" }
+      ];
+    });
   }
 } else if (figma.editorType === "figma") {
-  figma.showUI("<h1>This is Figma!</h1>");
+  figma.showUI(__html__); // Ensure you reference a proper HTML file
 }

--- a/document-change/code.ts
+++ b/document-change/code.ts
@@ -3,24 +3,29 @@ figma.showUI(__html__, { height: 600, width: 600 });
 void initialize();
 
 async function initialize() {
-  await figma.loadAllPagesAsync();
+  if ("loadAllPagesAsync" in figma) {
+    await figma.loadAllPagesAsync();
+  }
+
   figma.on("documentchange", (event) => {
     const messages = event.documentChanges.map(documentChangeAsString);
-    figma.ui.postMessage(messages, { origin: "*" });
+    figma.ui.postMessage(messages);
   });
 }
 
-function documentChangeAsString(change: DocumentChange) {
+function documentChangeAsString(change: DocumentChange): string {
   const { origin, type } = change;
   const list: string[] = [origin, type];
+
   if (type === "PROPERTY_CHANGE") {
     list.push(change.node.type, change.properties.join(", "));
   } else if (type === "STYLE_PROPERTY_CHANGE") {
-    list.push(change.style?.name, change.properties.join(", "));
-  } else if (type === "STYLE_CREATE" || type === "STYLE_DELETE") {
-    // noop
-  } else {
+    if (change.style) {
+      list.push(change.style.name, change.properties.join(", "));
+    }
+  } else if (type !== "STYLE_CREATE" && type !== "STYLE_DELETE") {
     list.push(change.node.type);
   }
+
   return list.join(" ");
 }


### PR DESCRIPTION
Ensure figma.loadAllPagesAsync() is supported

This API is not officially documented, and if it doesn’t exist, it will throw an error. You might want to check if it exists before calling it.
figma.ui.postMessage should not use { origin: "*" }

The second argument for figma.ui.postMessage is unnecessary, as it only accepts a single argument in Figma Plugins.
Ensure change.style is defined before accessing .name

You are using change.style?.name, but in some cases, change.style may be undefined. You should check it explicitly.
